### PR TITLE
SBM-24444 Stop OpenX and Sovrn from timing out the auction.

### DIFF
--- a/modules/openxBidAdapter.js
+++ b/modules/openxBidAdapter.js
@@ -95,6 +95,25 @@ export const spec = {
       adUnits = [];
     }
     bidResponses = createBidResponses(adUnits, bidRequest.payload);
+
+    // Create an empty bidResponse for all bids that did not come back.
+    const responseIds = bidResponses.map((bidResponse) => bidResponse.requestId);
+    bidRequest.payload.bids.forEach((bid) => {
+      if (responseIds.indexOf(bid.bidId) === -1) {
+        bidResponses.push({
+          requestId: bid.bidId,
+          cpm: 0,
+          width: 1,
+          height: 1,
+          creativeId: null,
+          dealId: null,
+          currency: 'USD',
+          netRevenue: true,
+          mediaType: _mediaTypes.BANNER,
+          ttl: 60000
+        })
+      }
+    });
     return bidResponses;
   }
 };

--- a/modules/openxBidAdapter.js
+++ b/modules/openxBidAdapter.js
@@ -110,7 +110,8 @@ export const spec = {
           currency: 'USD',
           netRevenue: true,
           mediaType: _mediaTypes.BANNER,
-          ttl: 60000
+          ttl: 60000,
+          ad: null
         })
       }
     });

--- a/modules/sovrnBidAdapter.js
+++ b/modules/sovrnBidAdapter.js
@@ -93,7 +93,8 @@ export const spec = {
             currency: 'USD',
             netRevenue: true,
             mediaType: _mediaTypes.BANNER,
-            ttl: 60000
+            ttl: 60000,
+            ad: null
           });
         }
       });

--- a/modules/sovrnBidAdapter.js
+++ b/modules/sovrnBidAdapter.js
@@ -52,14 +52,16 @@ export const spec = {
    * @param {id, seatbid} sovrnResponse A successful response from Sovrn.
    * @return {Bid[]} An array of formatted bids.
   */
-  interpretResponse: function({ body: {id, seatbid} }) {
+  interpretResponse: function({ body: {id, seatbid} }, request) {
     let sovrnBidResponses = [];
+    const responseIds = []
     if (id &&
       seatbid &&
       seatbid.length > 0 &&
       seatbid[0].bid &&
       seatbid[0].bid.length > 0) {
       seatbid[0].bid.map(sovrnBid => {
+        responseIds.push(sovrnBid.impid);
         sovrnBidResponses.push({
           requestId: sovrnBid.impid,
           cpm: parseFloat(sovrnBid.price),
@@ -74,6 +76,29 @@ export const spec = {
           ttl: 60000
         });
       });
+    }
+    // Generate a zero cent bid for all of the bid requests that did not have responses.
+    // This will ensure that Prebid does not wait for bids that will never come back.
+    try {
+      const bidRequestObj = JSON.parse(request.data);
+      bidRequestObj.imp.forEach((bidRequest) => {
+        if (responseIds.indexOf(bidRequest.id) === -1) {
+          sovrnBidResponses.push({
+            requestId: bidRequest.id,
+            cpm: 0,
+            width: 1,
+            height: 1,
+            creativeId: null,
+            dealId: null,
+            currency: 'USD',
+            netRevenue: true,
+            mediaType: _mediaTypes.BANNER,
+            ttl: 60000
+          });
+        }
+      });
+    } catch (e) {
+
     }
     return sovrnBidResponses;
   }


### PR DESCRIPTION
After digging into this data, I noticed that OpenX and Sovrn rarely return all of their bids. This causes the auction to wait for them to respond. 

## To Test
This PR documents some of the debugging I was using to make sure all OpenX and Sovrn bids are marked as returned: https://github.com/studybreakmedia/ad-vantage.js/pull/811/files

It appears that AOL and districtM also both cause the auction to be delayed. They both use a single request per bid, so as far as I can tell we can not do the same logic here.